### PR TITLE
Now _version works for acpype.sh in any folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,20 +22,22 @@ COPY amber21-11_linux/dat /usr/local/dat
 
 COPY acpype_lib/acpype.py /home/
 
+RUN bash /home/amber21/amber.sh
+
 RUN touch /root/.bashrc \
  && echo "export AMBERHOME='/home/amber21'\nexport ACHOME='/home/amber21/bin'\nexport LD_LIBRARY_PATH='/home/amber21/lib'\n" >> /root/.bashrc
 
-RUN cd /home/ && ln -s $PWD/acpype.py /usr/local/bin/acpype
+RUN cd /home/ && ln -s $PWD/acpype.sh /usr/local/bin/acpype
 
-RUN cd /home/amber21/bin/to_be_dispatched && ln -s $PWD/antechamber /usr/local/bin/antechamber
+RUN cd /home/amber21/bin && ln -s $PWD/antechamber /usr/local/bin/antechamber
 
-RUN cd /home/amber21/bin/to_be_dispatched && ln -s $PWD/charmmgen /usr/local/bin/charmmgen
+RUN cd /home/amber21/bin && ln -s $PWD/charmmgen /usr/local/bin/charmmgen
 
-RUN cd /home/amber21/bin/ && ln -s $PWD/tleap /usr/local/bin/tleap
+RUN cd /home/amber21/bin && ln -s $PWD/tleap /usr/local/bin/tleap
 
-RUN cd /home/amber21/bin/ && ln -s $PWD/teLeap /usr/local/bin/teLeap
+RUN cd /home/amber21/bin && ln -s $PWD/teLeap /usr/local/bin/teLeap
 
-RUN cd /home/amber21/bin/to_be_dispatched && ln -s $PWD/parmchk2 /usr/local/bin/parmchk2
+RUN cd /home/amber21/bin && ln -s $PWD/parmchk2 /usr/local/bin/parmchk2
 
 ENV ACHOME="/home/amber21/bin"
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Topologies files to be generated so far: CNS/XPLOR, GROMACS, CHARMM and AMBER.
 Field (GAFF) and should be used only with compatible forcefields like AMBER and
 its variant.
 
-Several flavours of AMBER FF are ported already for GROMACS (see ffamber:
-<http://ffamber.cnsm.csulb.edu/>) as well as to XPLOR/CNS (see `xplor-nih`:
-<http://ambermd.org/xplor-nih.html>) and [CHARMM](https://www.charmm.org/).
+Several flavours of AMBER FF are ported already for GROMACS (see [ffamber](http://ffamber.cnsm.csulb.edu/)) as well as to XPLOR/CNS (see [`xplor-nih`](http://ambermd.org/xplor-nih.html)) and [CHARMM](https://www.charmm.org/).
 
 This code is released under **[GNU General Public License V3](https://www.gnu.org/licenses/gpl-3.0.en.html)**.
 
@@ -32,8 +30,7 @@ It was inspired by:
 - `amb2gmx.pl` (Eric Sorin, David Mobley and John Chodera)
   and depends on `Antechamber` and `OpenBabel`
 
-- YASARA Autosmiles:
-  <http://www.yasara.org/autosmiles.htm> (Elmar Krieger)
+- [YASARA Autosmiles](http://www.yasara.org/autosmiles.htm) (Elmar Krieger)
 
 - `topolbuild` (Bruce Ray)
 
@@ -58,8 +55,7 @@ If you use this code, I am glad if you cite:
 
 > SOUSA DA SILVA, A. W. & VRANKEN, W. F.
 ACPYPE - AnteChamber PYthon Parser interfacE.
-BMC Research Notes 5 (2012), 367 doi: 10.1186/1756-0500-5-367
-<http://www.biomedcentral.com/1756-0500/5/367>
+BMC Research Notes 5 (2012), 367 doi: [10.1186/1756-0500-5-367](http://www.biomedcentral.com/1756-0500/5/367)
 
 and (optionally)
 
@@ -75,7 +71,7 @@ alanwilter _at_ gmail _dot_ com
 
 ##### Introduction
 
-We now have an up to date *webservice* at **<http://bio2byte.be/acpype/>** (but it **does not** have the `amb2gmx` funcionality).
+We now have an up to date *webservice* at **[Bio2Byte](http://bio2byte.be/acpype/)** (but it **does not** have the `amb2gmx` funcionality).
 
 To run `acpype`, locally, with its all functionalities, you need **ANTECHAMBER** from package
 [AmberTools](http://ambermd.org/) and

--- a/acpype_lib/_version.py
+++ b/acpype_lib/_version.py
@@ -1,10 +1,18 @@
+import os
 from subprocess import run, STDOUT, PIPE
 
-out = run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE)
+
+def run_git():
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    return run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE)
+
+
+out = run_git()
 
 if out.returncode == 0:
 
     version = out.stdout.decode()[0:10]
+    version = out.stdout.decode().rsplit("-", 1)[0]
 else:
     try:
         from importlib.metadata import version as ver

--- a/acpype_lib/_version.py
+++ b/acpype_lib/_version.py
@@ -1,12 +1,12 @@
-# import os
+import os
 from subprocess import run, STDOUT, PIPE
 
 
 def run_git():
-    #   cur_dir = os.getcwd()
-    #   os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    cur_dir = os.getcwd()
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
     ver = run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE)
-    #   os.chdir(cur_dir)
+    os.chdir(cur_dir)
     return ver
 
 
@@ -14,8 +14,8 @@ out = run_git()
 
 if out.returncode == 0:
 
-    version = out.stdout.decode()[0:10]
-#   version = out.stdout.decode().rsplit("-", 1)[0]
+    decode = out.stdout.decode()[0:10]
+    version = decode.rsplit("-", 1)[0]
 else:
     try:
         from importlib.metadata import version as ver

--- a/acpype_lib/_version.py
+++ b/acpype_lib/_version.py
@@ -15,7 +15,7 @@ out = run_git()
 if out.returncode == 0:
 
     version = out.stdout.decode()[0:10]
-    version = out.stdout.decode().rsplit("-", 1)[0]
+#   version = out.stdout.decode().rsplit("-", 1)[0]
 else:
     try:
         from importlib.metadata import version as ver

--- a/acpype_lib/_version.py
+++ b/acpype_lib/_version.py
@@ -3,8 +3,11 @@ from subprocess import run, STDOUT, PIPE
 
 
 def run_git():
+    cur_dir = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
-    return run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE)
+    ver = run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE)
+    os.chdir(cur_dir)
+    return ver
 
 
 out = run_git()

--- a/acpype_lib/_version.py
+++ b/acpype_lib/_version.py
@@ -14,8 +14,7 @@ out = run_git()
 
 if out.returncode == 0:
 
-    decode = out.stdout.decode()[0:10]
-    version = decode.rsplit("-", 1)[0]
+    version = out.stdout.decode().rsplit("-", 1)[0].replace("-", ".")
 else:
     try:
         from importlib.metadata import version as ver

--- a/acpype_lib/_version.py
+++ b/acpype_lib/_version.py
@@ -1,12 +1,12 @@
-import os
+# import os
 from subprocess import run, STDOUT, PIPE
 
 
 def run_git():
-    cur_dir = os.getcwd()
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    #   cur_dir = os.getcwd()
+    #   os.chdir(os.path.dirname(os.path.abspath(__file__)))
     ver = run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE)
-    os.chdir(cur_dir)
+    #   os.chdir(cur_dir)
     return ver
 
 

--- a/acpype_lib/acpype.py
+++ b/acpype_lib/acpype.py
@@ -2305,9 +2305,8 @@ class AbstractTopol:
         elif "gaff2" in self.atomType:
             cmd += " -s 2"
 
-        self.parmchkLog = _getoutput(cmd)
-
         self.printDebug(cmd)
+        self.parmchkLog = _getoutput(cmd)
 
         if os.path.exists(self.acFrcmodFileName):
             check = self.checkFrcmod()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,5 +25,5 @@ test:
 
 about:
   home: https://github.com/alanwilter/acpype
-  license: GPL3
+  license: GPL-3.0-or-later
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  git_rev: "recipe"
   git_url: https://github.com/alanwilter/acpype.git
+  git_tag: fix_version
 
 requirements:
   host:
@@ -21,7 +21,7 @@ requirements:
 
 test:
   commands:
-    - acpype -h
+    - acpype -v
 
 about:
   home: https://github.com/alanwilter/acpype

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
+  git_rev: "recipe"
   git_url: https://github.com/alanwilter/acpype.git
-  git_tag: fix_version
 
 requirements:
   host:

--- a/recipe/setup_conda.py
+++ b/recipe/setup_conda.py
@@ -22,7 +22,7 @@ setup(
     author="Alan Wilter Sousa da Silva",
     author_email="alanwilter@gmail.com",
     license="GPL3",
-    packages=["acpype_lib"],
+    packages=["acpype", "acpype_lib"],
     keywords=["acpype"],
     include_package_data=True,
     entry_points={"console_scripts": ["acpype = acpype_lib.acpype:init_main"]},

--- a/recipe/setup_conda.py
+++ b/recipe/setup_conda.py
@@ -8,7 +8,9 @@ and to interface with others python applications like CCPN or ARIA.
 from setuptools import setup
 from subprocess import run, STDOUT, PIPE
 
-version = str(run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE).stdout.decode()[0:10]).rsplit("-", 1)[0]
+version = str(run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE).stdout.decode()[0:10]).rsplit(
+    "-", 1
+)[0]
 
 setup(
     name="acpype",

--- a/recipe/setup_conda.py
+++ b/recipe/setup_conda.py
@@ -6,7 +6,9 @@ and to interface with others python applications like CCPN or ARIA.
 """
 
 from setuptools import setup
-from acpype_lib._version import version
+from subprocess import run, STDOUT, PIPE
+
+version = str(run("git describe --tags --always", shell=True, stderr=STDOUT, stdout=PIPE).stdout.decode()[0:10]).rsplit("-", 1)[0]
 
 setup(
     name="acpype",

--- a/recipe/setup_conda.py
+++ b/recipe/setup_conda.py
@@ -24,7 +24,7 @@ setup(
     author="Alan Wilter Sousa da Silva",
     author_email="alanwilter@gmail.com",
     license="GPL3",
-    packages=["acpype", "acpype_lib"],
+    packages=["acpype_lib"],
     keywords=["acpype"],
     include_package_data=True,
     entry_points={"console_scripts": ["acpype = acpype_lib.acpype:init_main"]},


### PR DESCRIPTION
When using `acpype -v` command (symlinked to `.../acpype.sh`), for those who installed it via git, then it gets the right version.

Don't know if it will affect conda etc. It shouldn't.