### PR TITLE
Fix test-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ There are several ways of obtaining `acpype`:
 At folder `acpype/`, type:
 
 ```bash
-./run_acpype.py -i test/FFF.pdb
+./run_acpype.py -i tests/FFF.pdb
 ```
 
 It'll create a folder called *FFF.acpype*, and inside it one may find topology


### PR DESCRIPTION
I have found the wrong test-command in README.md.
https://github.com/alanwilter/acpype/blob/5e66143b87f71d1af67a9d56914d733f19d74104/README.md?plain=1#L177

So, I fix the command like this↓

```bash
./run_acpype.py -i tests/FFF.pdb #before : test/FFF.pdb
```

Could you check this?
