### PR TITLE
Fix GitHub language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# GitHub language detection
+acpype/amber*/**     linguist-vendored


### PR DESCRIPTION
This is a petty detail, but I found misleading that the main language displayed by GitHub is _Rich Text Format_ instead of _Python_. 

Adding a `.gitattributes` file with a [vendored code](https://github.com/github/linguist/blob/master/docs/overrides.md#vendored-code) specification on the amber related files would solve it. And would get a more realistic representation of the languages coded.