### PR TITLE
fix: UnboundLocalError on output variable on acs_api

### DIFF
--- a/acpype/acs_api.py
+++ b/acpype/acs_api.py
@@ -95,6 +95,7 @@ def acpype_api(
     chiral=False,
     is_smiles=False,
 ):
+    output = {}
     at0 = time.time()
     print(header)
 


### PR DESCRIPTION
Suppose we have this code

```py
from acpype import acs_api

acs_api.acpype_api("2mu8.pdb")
```

On the latest release we get `UnboundLocalError: cannot access local variable 'output' where it is not associated with a value` when running. That is due to python being unable to reference a variable in a uninitialized state.

This PR initializes said variable at the start of the function, thus, it works as intended.