### PR TITLE
Handle the competition for parmGaffffxxSBFile when running acpype concurrently.

### DIFF
--- a/acpype/utils.py
+++ b/acpype/utils.py
@@ -150,6 +150,9 @@ def parmMerge(fdat1, fdat2, frcmod=False):
     else:
         name2 = os.path.basename(fdat2).split(".dat")[0]
     mname = "/tmp/" + name1 + name2 + ".dat"
+    if os.path.exists(mname):
+        if os.path.getsize(mname):
+            return mname
     mdatFile = open(mname, "w")
     mdat = [f"merged {name1} {name2}"]
 


### PR DESCRIPTION
When acpype is concurrent on a host, there is a chance of writing the parmGaffffxxSBFile file simultaneously. Therefore, add simple judgments to avoid this issue as much as possible.