### PR TITLE
Correct atom type mass in gromacs itp

### DIFF
--- a/acpype/topol.py
+++ b/acpype/topol.py
@@ -2206,7 +2206,7 @@ class AbstractTopol(abc.ABC):
                 % (
                     aTypeName,
                     aTypeName,
-                    0.0,
+                    aType.mass,
                     0.0,
                     sigma,
                     epsilon,


### PR DESCRIPTION
The program always gave 0 as atom type mass in the gromacs itp atom types.

Fixes the mass output of issue #132 